### PR TITLE
Fix validation for economic code length

### DIFF
--- a/src/Moadian.php
+++ b/src/Moadian.php
@@ -108,9 +108,9 @@ class Moadian
 
     public function getEconomicCodeInformation(string $taxID)
     {
-        if (strlen($taxID) < 9 || strlen($taxID) >= 12)
-            throw new MoadianException('$taxID must be between 10 and 11 digits');
-
+        if (!preg_match('/^(\d{11}|\d{14})$/', $taxID))
+            throw new MoadianException('Economic code must be 11 digits for legal entities or 14 digits for natural persons');
+            
         $request = new EconomicCodeInformation($taxID);
         return $this->sendRequest($request);
     }


### PR DESCRIPTION
- Fixed taxID length validation to accept 11 digits (legal entities) or 14 digits (natural persons).  
- Replaced `strlen` with `preg_match` for better readability and accuracy.  
- Updated exception message for clearer explanation.

Reference: [Error List - Malitor](https://malitor.ir/E
![photo_2025-02-08_14-47-53](https://github.com/user-attachments/assets/26122e79-eebb-44cd-87e0-8dfa12f47336)
rrorList)